### PR TITLE
fix: disable R-CMD-CHECK action until code is stable

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,9 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    branches: [main, master]
-  pull_request:
+on: workflow_dispatch
 
 name: R-CMD-check.yaml
 


### PR DESCRIPTION
This PR simply disables the use of the R-CMD-CHECK GitHub Action until we have a stable code base. I deleted the PR template language since it is not applicable for this minor change.